### PR TITLE
chore: integrate rock image test:1.1.0v2

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -27,8 +27,9 @@ options:
       when uploading a new version of a pipeline
   cache-image:
     type: string
-    default: "registry.k8s.io/busybox"
-    description: Which image to list as the backing image for a pipeline run step pulled from cache
+    default: "misohu/test:1.1.0v2"
+    description: Which image to list as the backing image for a pipeline run 
+      step pulled from cache
   cache-enabled:
     type: boolean
     default: true

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/api-server:2.4.1-7e49e8b
+    upstream-source: misohu/test:1.1.0v2
 requires:
   mysql:
     interface: mysql
@@ -35,8 +35,8 @@ requires:
               type: string
             namespace:
               type:
-              - string
-              - 'null'
+                - string
+                - 'null'
             port:
               type: number
             secret-key:
@@ -46,13 +46,14 @@ requires:
             service:
               type: string
           required:
-          - access-key
-          - port
-          - secret-key
-          - secure
-          - service
+            - access-key
+            - port
+            - secret-key
+            - secure
+            - service
     versions: [v1]
-    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
+    __schema_source: 
+      https://raw.githubusercontent.com/canonical/operator-schemas/master/object-storage.yaml
   kfp-viz:
     interface: k8s-service
     schema:
@@ -65,10 +66,11 @@ requires:
             service-port:
               type: string
           required:
-          - service-name
-          - service-port
+            - service-name
+            - service-port
     versions: [v1]
-    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    __schema_source: 
+      https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   logging:
     interface: loki_push_api
     optional: true
@@ -85,10 +87,11 @@ provides:
             service-port:
               type: string
           required:
-          - service-name
-          - service-port
+            - service-name
+            - service-port
     versions: [v1]
-    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    __schema_source: 
+      https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   metrics-endpoint:
     interface: prometheus_scrape
   grafana-dashboard:


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-api/metadata.yaml`
  - **Path**: `resources.oci-image.upstream-source`

- **File**: `charms/kfp-api/config.yaml`
  - **Path**: `options.cache-image.default`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-api/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  
  - Manually set **command** to: `f"bash -c '{self._exec_command}'"
`
  

