### PR TITLE
chore: integrate rock image test:1.1.0

### DIFF
--- a/charms/kfp-api/config.yaml
+++ b/charms/kfp-api/config.yaml
@@ -27,7 +27,7 @@ options:
       when uploading a new version of a pipeline
   cache-image:
     type: string
-    default: "registry.k8s.io/busybox"
+    default: "misohu/test:1.1.0"
     description: Which image to list as the backing image for a pipeline run step pulled from cache
   cache-enabled:
     type: boolean

--- a/charms/kfp-api/metadata.yaml
+++ b/charms/kfp-api/metadata.yaml
@@ -16,7 +16,7 @@ resources:
     type: oci-image
     description: Backing OCI image
     # The container's `user` needs to be updated when switching from upstream image to rock
-    upstream-source: docker.io/charmedkubeflow/api-server:2.4.1-7e49e8b
+    upstream-source: misohu/test:1.1.0
 requires:
   mysql:
     interface: mysql


### PR DESCRIPTION
This PR was opened automatically by the `charmed-analytics-ci` library as part of the Rock CI system after the rock image was built and published.

## 🔧 Updated Rock References

The following image paths were updated:


- **File**: `charms/kfp-api/metadata.yaml`
  - **Path**: `resources.oci-image.upstream-source`

- **File**: `charms/kfp-api/config.yaml`
  - **Path**: `options.cache-image.default`





## ⚠️ Manual Action Required

The following service-spec files were **not found** in the repository and should be updated manually:


- **File**: `charms/kfp-api/service-config.yaml`
  
  - Manually set **user** to: `_daemon_`
  
  
  - Manually set **command** to: `f"bash -c '{self._exec_command}'"
`
  

